### PR TITLE
Add ca-certificates requirement to installation instructions

### DIFF
--- a/usage/install-on-desktops.md
+++ b/usage/install-on-desktops.md
@@ -25,6 +25,11 @@ Waydroid requires the following in order to work properly on your PC:
 
 ### Install Waydroid
 
+Install ca-certificates, if not already installed.
+```bash
+sudo apt install ca-certificates
+```
+
 Add the repo to your `sources.list`
 
 * **Add waydroid repo** _(for droidian & ubports, this step can be skipped)_ Replace `DISTRO="bullseye"` with your current target. Options: **focal**, **bullseye**, **hirsute**


### PR DESCRIPTION
This will fix a lot of issues where people can't install waydroid
due to apt not recognizing that the connection to the repository is
secure due to the absense of the required certificates