### PR TITLE
adding the command to get the distro codename for clarity

### DIFF
--- a/usage/install-on-desktops.md
+++ b/usage/install-on-desktops.md
@@ -30,6 +30,11 @@ Install ca-certificates, if not already installed.
 sudo apt install ca-certificates
 ```
 
+Check your distro (codename) for the next step
+```bash
+lsb_release -c
+```
+
 Add the repo to your `sources.list`
 
 * **Add waydroid repo** _(for droidian & ubports, this step can be skipped)_ Replace `DISTRO="bullseye"` with your current target. Options: **focal**, **bullseye**, **hirsute**


### PR DESCRIPTION
If the distro is not specified correctly there are errors (such as from python).   A user may not know or remember the code name so adding the command so that the user can quickly reference this.