### PR TITLE
Fix `repo sync` failing due to GitHub auth changes

### DIFF
--- a/development/compile-waydroid-lineage-os-based-images.md
+++ b/development/compile-waydroid-lineage-os-based-images.md
@@ -9,7 +9,7 @@ To get started with Android/LineageOS, you'll need to get familiar with [Repo](h
 To initialize your local repository using the LineageOS trees, use a command like this:
 
 ```text
-repo init -u git://github.com/LineageOS/android.git -b lineage-17.1
+repo init -u https://github.com/LineageOS/android.git -b lineage-17.1
 ```
 
 Then we grab the Waydroid local\_manifests


### PR DESCRIPTION
That's what happened on my machine when I tried to `repo sync` today:
```
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
manifests: sleeping 4.0 seconds before retrying
```
Apparently `git://` protocol doesn't work anymore if you're unauthenticated. This change should help alleviate the issue.

P.S Fuck you Microsoft, breaking developer workflow every 2-3 months by making changes to your platform is very much not appreciated. 