### PR TITLE
faq: disable onscreen keyboard: typo

### DIFF
--- a/faq/disable-on-screen-keyboard.md
+++ b/faq/disable-on-screen-keyboard.md
@@ -10,8 +10,7 @@ You can disable on-screen keyboard by two methods,
 
 #### From command-line:
 
-  `# lxc-attach -P /var/lib/waydroid/lxc/ -n waydroid --clear-env pm disable com.android.inputmethod.
-latin`
+  `# lxc-attach -P /var/lib/waydroid/lxc/ -n waydroid --clear-env pm disable com.android.inputmethod.latin`
 
 #### Going to settings app and selecting Apps & notifications:
 


### PR DESCRIPTION
the space here `method. latin` makes the command error, removing the space fixes it.