### PR TITLE
Reflect that ashmem is no longer required, grammar

### DIFF
--- a/debugging/getting-essential-information.md
+++ b/debugging/getting-essential-information.md
@@ -8,13 +8,13 @@ Useful information belongs in two places the methods of getting this information
 
 `sudo waydroid logcat > ~/waydroid-logcat.txt`
 
-It is also important to make sure your kernel supports binder and either ashmem or memfd, you can verify support in your kernel by using this command. 
-
-`zgrep -i -e android -e memfd -e ashmem /proc/config.gz`
-
-Or on Debian based distros:
+It is also important to make sure your kernel supports binder and either ashmem or memfd, you can verify support in your kernel by using one of the following commands. 
 
 `grep -i -e android -e memfd -e ashmem "/boot/config-$(uname -r)"`
+
+Or on some distros:
+
+`zgrep -i -e android -e memfd -e ashmem /proc/config.gz`
 
 If you do not have support, you may need to change to a supported kernel or look at patched anbox-modules.dkms.
 

--- a/debugging/getting-essential-information.md
+++ b/debugging/getting-essential-information.md
@@ -1,6 +1,6 @@
 # Getting Essential Information
 
-Useful information belongs in two places the methods of getting this information are as follows. if someone asks for the logs, it is best to give them the full output of these commands as well as include them on any issue tickets you create.
+Useful information belongs in two places the methods of getting this information are as follows. If someone asks for the logs, it is best to give them the full output of these commands as well as include them on any issue tickets you create:
 
 `sudo systemctl status waydroid-container.service`
 
@@ -8,11 +8,17 @@ Useful information belongs in two places the methods of getting this information
 
 `sudo waydroid logcat > ~/waydroid-logcat.txt`
 
-It is also important to make sure your kernel supports ashmem and binder, you can verify support in your kernel by using this command. if you do not have support, you may need to change to a supported kernel or look at patched anbox-modules.dkms
+It is also important to make sure your kernel supports binder and either ashmem or memfd, you can verify support in your kernel by using this command. 
 
-`zgrep -i -e android -e ashmem /proc/config.gz`&#x20;
+`zgrep -i -e android -e memfd -e ashmem /proc/config.gz`
 
-Another important piece of information is knowing what linux enviroment you are using. these two commands contain the relevant information
+Or on Debian based distros:
+
+`grep -i -e android -e memfd -e ashmem "/boot/config-$(uname -r)"`
+
+If you do not have support, you may need to change to a supported kernel or look at patched anbox-modules.dkms.
+
+Another important piece of information is knowing what linux enviroment you are using. These two commands contain the relevant information:
 
 `lsb_release -a` and `uname -a`
 


### PR DESCRIPTION
Debian based distros have no /proc/config.gz, so add an additional check from /boot/config files