### PR TITLE
Substitute Android's version control link to a working one

### DIFF
--- a/development/compile-waydroid-lineage-os-based-images.md
+++ b/development/compile-waydroid-lineage-os-based-images.md
@@ -2,7 +2,7 @@
 
 ## Getting started
 
-To get started with Android/LineageOS, you'll need to get familiar with [Repo](https://source.android.com/source/using-repo.html) and [Version Control with Git](https://source.android.com/source/version-control.html).
+To get started with Android/LineageOS, you'll need to get familiar with [Repo](https://source.android.com/source/using-repo.html) and [it's workflow with Git](https://source.android.com/docs/setup/create/coding-tasks).
 
 ### Initializing
 

--- a/development/compile-waydroid-lineage-os-based-images.md
+++ b/development/compile-waydroid-lineage-os-based-images.md
@@ -2,7 +2,7 @@
 
 ## Getting started
 
-To get started with Android/LineageOS, you'll need to get familiar with [Repo](https://source.android.com/source/using-repo.html) and [it's workflow with Git](https://source.android.com/docs/setup/create/coding-tasks).
+To get started with Android/LineageOS, you'll need to get familiar with [Repo](https://source.android.com/source/using-repo.html) and its [Git workflow](https://source.android.com/docs/setup/create/coding-tasks).
 
 ### Initializing
 


### PR DESCRIPTION
The page seems to return 404 for a long time.