### PR TITLE
Drop Pop!_OS specific steps

### DIFF
--- a/usage/install-on-desktops.md
+++ b/usage/install-on-desktops.md
@@ -59,19 +59,6 @@ Waydroid can be installed from the official package repository; also check `/usr
 sudo xbps-install -S waydroid
 ```
 
-## PopOS
-
-* Install the required kernel modules:
-{% embed url="https://github.com/choff/anbox-modules#install-instruction" %}
-
-* Load other required modules:
-```bash
-sudo mkdir /etc/modules-load.d
-echo "nft_xfrm" | sudo tee -a /etc/modules-load.d/waydroid.conf
-sudo modprobe nft_xfrm
-```
-* Follow the install instructions for Ubuntu below
-
 ## Ubuntu/Debian and derivatives
 
 For Droidian and Ubuntu Touch, skip directly to the last step


### PR DESCRIPTION
This has reportedly[1][2] made people's installation unbootable; as tested on the default kernel `v6.4.6-76060406-generic` it is configured already with:
```
CONFIG_ANDROID_BINDER_IPC=y
CONFIG_ANDROID_BINDERFS=y
CONFIG_ANDROID_BINDER_DEVICES=""
# CONFIG_ANDROID_BINDER_IPC_SELFTEST is not set
```

This is also true on (at least an up-to-date) 20.04 setup[3] so there really isn't any need for these extra steps and simply following the Ubuntu steps is enough.

[1] https://www.reddit.com/r/pop_os/comments/120lojm/pop_os_doesnt_boot_after_trying_to_install/
[2] https://t.me/WayDroid/155405
[3] https://github.com/waydroid/docs/pull/58#issuecomment-1678497140