### PR TITLE
Remove unnecessary sudo for rpm-ostree install instructions

### DIFF
--- a/usage/install-on-desktops.md
+++ b/usage/install-on-desktops.md
@@ -49,7 +49,7 @@ Vendor OTA: `https://ota.waydro.id/vendor`
 The same instructions apply to the Fedora Immutable variants, but you should use `rpm-ostree` instead of `dnf`
 
 ```bash
-sudo rpm-ostree install waydroid
+rpm-ostree install waydroid
 ```
 
 ## KISS Linux


### PR DESCRIPTION
sudo is not necessary for installing packages with rpm-ostree. See https://docs.fedoraproject.org/en-US/fedora-silverblue/getting-started/#_installing_packages for details.