### PR TITLE
usage/install-on-desktops: update nixos link to official wiki url

### DIFF
--- a/usage/install-on-desktops.md
+++ b/usage/install-on-desktops.md
@@ -87,7 +87,7 @@ Then start Waydroid from the applications menu.
 
 NixOS community has a wiki page for WayDroid:
 
-{% embed url="https://nixos.wiki/wiki/WayDroid" %}
+{% embed url="https://wiki.nixos.org/wiki/WayDroid" %}
 
 # Troubleshooting
 


### PR DESCRIPTION
This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org/

ref: NixOS/foundation#113