### PR TITLE
Adding openSUSE guide for openSUSE users (except Leap)

### DIFF
--- a/usage/install-on-desktops.md
+++ b/usage/install-on-desktops.md
@@ -45,6 +45,11 @@ The same instructions apply to the Fedora Immutable variants, but you should use
 ```bash
 rpm-ostree install waydroid
 ```
+## openSUSE Tumbleweed/SLowroll
+
+User @runa-chin had created a detailed guide about installing Waydroid on openSUSE Tumbleweed or openSUSE Slowroll
+
+{% embed url="https://github.com/waydroid/waydroid/discussions/1463" %}
 
 ## KISS Linux
 

--- a/usage/install-on-desktops.md
+++ b/usage/install-on-desktops.md
@@ -47,7 +47,7 @@ rpm-ostree install waydroid
 ```
 ## openSUSE Tumbleweed/SLowroll
 
-User @runa-chin had created a detailed guide about installing Waydroid on openSUSE Tumbleweed or openSUSE Slowroll
+User @runa-chin had created a detailed guide about installing Waydroid on openSUSE Tumbleweed or openSUSE Slowroll:
 
 {% embed url="https://github.com/waydroid/waydroid/discussions/1463" %}
 

--- a/usage/install-on-desktops.md
+++ b/usage/install-on-desktops.md
@@ -45,7 +45,7 @@ The same instructions apply to the Fedora Immutable variants, but you should use
 ```bash
 rpm-ostree install waydroid
 ```
-## openSUSE Tumbleweed/SLowroll
+## openSUSE Tumbleweed/Slowroll
 
 User @runa-chin had created a detailed guide about installing Waydroid on openSUSE Tumbleweed or openSUSE Slowroll:
 


### PR DESCRIPTION
Hello, I was wondering if I could add some docs for openSUSE Tumbleweed and Slowroll users to the official WayDroid documentation to make it easier for openSUSE users to install WayDroid. Hopefully, my request and addition will be accepted soon. Please accept if there are no errors. Thank you. Feel free to send me suggestions if something wrong.