### PR TITLE
Use silent mode for curl

### DIFF
--- a/usage/install-on-desktops.md
+++ b/usage/install-on-desktops.md
@@ -80,7 +80,7 @@ sudo apt install curl ca-certificates -y
 
 * Add the official repository
 ```bash
-curl https://repo.waydro.id | sudo bash
+curl -s https://repo.waydro.id | sudo bash
 ```
 If the script fails to detect your distribution, you can provide a valid option by appending `-s <DISTRO>`.
 Currently supported values are: **mantic**, **focal**, **jammy**, **kinetic**, **lunar**, **noble**, **bookworm**, **bullseye**, **trixie**, **sid**


### PR DESCRIPTION
While installing in Ubuntu systems, the curl download of the script shows the progress meter, which makes it hard to type password. With `-s`, the progress meter is not shown anymore.