### PR TITLE
docs: link to the `apply-waydroid-patches` script/func

### DIFF
--- a/development/compile-waydroid-lineage-os-based-images.md
+++ b/development/compile-waydroid-lineage-os-based-images.md
@@ -35,7 +35,7 @@ Then we setup the local build environment:
 
 ### Patching
 
-After that is complete, we apply the Waydroid patches:
+After that is complete, we apply the Waydroid patches [using the provided script](https://github.com/waydroid/android_vendor_waydroid/blob/b2fa4643f50488eefcfd415290bcfa445752e8c9/vendorsetup.sh#L4):
 
 ```text
 apply-waydroid-patches

--- a/development/manual-patch-resolution.md
+++ b/development/manual-patch-resolution.md
@@ -1,6 +1,6 @@
 # Manual Patch Resolution
 
-At the end of the `apply-waydroid-patches` script, it will show the results of how each patch applied. You will want to then make a copy of all the results of the patch scripts \(Copy and paste the contents of the terminal output into a Notepad or text document\). Each of the patches applied either resulted in "Applying", "Already applied", or "Conflicts". The only ones we want to pay attention to here are the "Conflicts", but only half of them.
+At the end of [the `apply-waydroid-patches` script](https://github.com/waydroid/android_vendor_waydroid/blob/b2fa4643f50488eefcfd415290bcfa445752e8c9/vendorsetup.sh#L4), it will show the results of how each patch applied. You will want to then make a copy of all the results of the patch scripts \(Copy and paste the contents of the terminal output into a Notepad or text document\). Each of the patches applied either resulted in "Applying", "Already applied", or "Conflicts". The only ones we want to pay attention to here are the "Conflicts", but only half of them.
 
 Some of the patches have duplicates for different vendor setups. So you will sometimes get results that look like this:
 


### PR DESCRIPTION
## Summary

The directions previously did not link to it so it was unclear where it came from and confused users
Fixes #62 

## Details

Adds an in-line link to the `apply-waydroid-patches` function when it is referenced for clarity