### PR TITLE
Add KWin Wayland session instructions to Waydroid-only sessions documentation

### DIFF
--- a/faq/setting-up-waydroid-only-sessions.md
+++ b/faq/setting-up-waydroid-only-sessions.md
@@ -88,3 +88,24 @@ Comment=Android OS in a container
 Exec=/usr/bin/wayfire-session.sh
 Type=Application
 ```
+
+### KWin Wayland
+
+`/usr/bin/kwin-waydroid.sh` contents:
+
+```
+#!/bin/sh
+kwin_wayland &
+sleep 5
+waydroid show-full-ui
+```
+
+`/usr/share/wayland-sessions/kwin.desktop` contents:
+
+```
+[Desktop Entry]
+Name=WayDroid on KWin
+Comment=Android OS in a container
+Exec=/usr/bin/kwin-waydroid.sh
+Type=Application
+```


### PR DESCRIPTION
Fixes #52

Add instructions for KWin Wayland to the Waydroid-only session documentation.

* Add a new section for KWin Wayland in `faq/setting-up-waydroid-only-sessions.md`.
* Include instructions for creating `/usr/bin/kwin-waydroid.sh`.
* Include instructions for creating `/usr/share/wayland-sessions/kwin.desktop`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/waydroid/docs/issues/52?shareId=XXXX-XXXX-XXXX-XXXX).