### PR TITLE
Fix typos in backup and restore documentation

### DIFF
--- a/faq/backup-restore-apps-and-data.md
+++ b/faq/backup-restore-apps-and-data.md
@@ -13,7 +13,7 @@ Go to Settings > System > Backup > Change backup provider. And choose Seedvault,
 ![](../.gitbook/assets/backup-provider.png)
 
 ### 2. Note down passphrase
-A passphrase is shown. This is used for encrytion. It wil asked on restoration.
+A passphrase is shown. This is used for encryption. It will be required for restoration.
 
 ![](../.gitbook/assets/backup-passphrase-copy.png)
 
@@ -31,7 +31,7 @@ Successfully backed up. The backup data will be at `~/.local/share/waydroid/data
 Copy the `.SeedVaultAndroidBackup` to  `~/.local/share/waydroid/data/media/0/`
 
 ### 2. Start restore activity.
-You need to run `am start com.stevesoltys.seedvault/.restore.RestoreActivity` in shell inorder to start the restoration activity. You can this either on `waydroid shell` or `adb shell`.
+You need to run `am start com.stevesoltys.seedvault/.restore.RestoreActivity` in shell inorder to start the restoration activity. You can do this either on `waydroid shell` or `adb shell`.
 
 ![](../.gitbook/assets/backup-restore-storage.png)
 

--- a/faq/backup-restore-apps-and-data.md
+++ b/faq/backup-restore-apps-and-data.md
@@ -31,7 +31,7 @@ Successfully backed up. The backup data will be at `~/.local/share/waydroid/data
 Copy the `.SeedVaultAndroidBackup` to  `~/.local/share/waydroid/data/media/0/`
 
 ### 2. Start restore activity.
-You need to run `am start com.stevesoltys.seedvault/.restore.RestoreActivity` in shell inorder to start the restoration activity. You can do this either on `waydroid shell` or `adb shell`.
+You need to run `am start com.stevesoltys.seedvault/.restore.RestoreActivity` in the shell in order to start the restoration activity. You can do this either on `waydroid shell` or `adb shell`.
 
 ![](../.gitbook/assets/backup-restore-storage.png)
 


### PR DESCRIPTION
Corrected typos and improved clarity in instructions on [faq page for backup and restore
](https://docs.waydro.id/faq/backup-restore-apps-and-data)

| Screenshot  1| screenshot 2 |
|--------|--------|
| <img width="606" height="97" alt="image" src="https://github.com/user-attachments/assets/2b16fca0-64b7-433d-9681-0bf9102ff735" /> | <img width="800" height="126" alt="image" src="https://github.com/user-attachments/assets/8dad8a58-f351-41e5-a062-f0b67f028fa4" /> |

@aleasto 