### PR TITLE
fix: Add link to disable touch sounds faq page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ The Android runtime environment ships with a minimal customized Android system i
 [disable-on-screen-keyboard.md](faq/disable-on-screen-keyboard.md)
 {% endcontent-ref %}
 
+{% content-ref url="faq/disable-touch-sounds.md" %}
+[disable-touch-sounds](faq/disable-touch-sounds.md)
+{% endcontent-ref %}
+
 {% content-ref url="faq/community-projects-we-like.md" %}
 [community-projects-we-like.md](faq/community-projects-we-like.md)
 {% endcontent-ref %}

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The Android runtime environment ships with a minimal customized Android system i
 {% endcontent-ref %}
 
 {% content-ref url="faq/disable-touch-sounds.md" %}
-[disable-touch-sounds](faq/disable-touch-sounds.md)
+[disable-touch-sounds.md](faq/disable-touch-sounds.md)
 {% endcontent-ref %}
 
 {% content-ref url="faq/community-projects-we-like.md" %}


### PR DESCRIPTION
After creating the [Touch Sounds Faq Page](https://docs.waydro.id/faq/disable-touch-sounds) the link was added in the SUMMARY.md file but not in the README.md file which prevented it form being accessible from the faq section of the home page.
<img width="1207" height="522" alt="image" src="https://github.com/user-attachments/assets/b5364e23-b607-4fad-b4f7-5dfecfe471fb" />
